### PR TITLE
JF-16: Add debounce & check internet connection functions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/app/src/main/java/ru/practicum/android/diploma/util/Connection.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/util/Connection.kt
@@ -1,0 +1,15 @@
+package ru.practicum.android.diploma.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+fun isInternetAvailable(context: Context): Boolean {
+    val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+    if (capabilities != null) {
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+    return false
+}

--- a/app/src/main/java/ru/practicum/android/diploma/util/Debounce.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/util/Debounce.kt
@@ -1,0 +1,31 @@
+package ru.practicum.android.diploma.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+fun <T> debounce(
+    delayMillis: Long,
+    coroutineScope: CoroutineScope,
+    useLastParam: Boolean,
+    action: (T) -> Unit,
+): (T) -> Unit {
+    var debounceJob: Job? = null
+    return { param: T ->
+        if (useLastParam) {
+            debounceJob?.cancel()
+        }
+        if (debounceJob?.isCompleted != false) {
+            debounceJob = coroutineScope.launch {
+                if (useLastParam) {
+                    delay(delayMillis)
+                    action(param)
+                } else {
+                    action(param)
+                    delay(delayMillis)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Есть два пункта на обсуждение по данному ПР:
1. Я создал для каждой функции свой файл, поскольку у нас целая папка под утилитарные функции. 
2. Использовал для проверки подключения метод из https://developer.android.com/develop/connectivity/network-ops/reading-network-state?hl=ru#restrictions и https://stackoverflow.com/a/41063539/2220789 а не из теории ЯП
Что думаете?